### PR TITLE
Update package banner in the manual

### DIFF
--- a/doc/funct.xml
+++ b/doc/funct.xml
@@ -15,10 +15,13 @@ To use the &UnitLib; package first you need to load it as follows:
 <![CDATA[
 gap> LoadPackage("unitlib");
 ----------------------------------------------------------------------------
-Loading  UnitLib 3.1.0 (The library of normalized unit groups of modular group algebras)
+Loading  UnitLib 4.0.0 (The library of normalized unit groups of modular group algebras)
 by Alexander Konovalov (https://alexk.host.cs.st-andrews.ac.uk) and
    Elena Yakimenko.
-Homepage: https://gap-packages.github.io/unitlib/
+maintained by:
+   Alexander Konovalov (https://alexk.host.cs.st-andrews.ac.uk).
+Homepage: https://gap-packages.github.io/unitlib
+Report issues at https://github.com/gap-packages/unitlib/issues
 ----------------------------------------------------------------------------
 true
 ]]>


### PR DESCRIPTION
<s>This PR has an ulterior motive: I suspect there still might something wrong with CI tests for PRs, but perhaps only for PRs submitted from a separate fork (my previous forks were from branches which I had put into `gap-packages/unitlib`, this one is from `fingolfin/unitlib`.

So please do not merge for now until this is resolved.</s>

OK, I think the CI tests here are good for now. So perhaps it is the reverse from what I thought, and the `CI / ${{ matrix.gap-branch }} ${{ matrix.ABI }} (pull_request) ` only appears for "internal" PRs which originate from a branch on the main repo... Theory: perhaps it happens because the `if:...` expression skipping the tests is outside the matrix and thus it skips the test before ever expanding the matrix. That might explain it (it doesn't explain the weirdness we saw before, but, oh well...)